### PR TITLE
解决测试用例的description中存在双引号的问题

### DIFF
--- a/unittestreport/core/testResult.py
+++ b/unittestreport/core/testResult.py
@@ -83,6 +83,8 @@ class TestResult(unittest.TestResult):
         test.class_name = test.__class__.__qualname__
         test.method_name = test.__dict__['_testMethodName']
         test.method_doc = test.shortDescription()
+        if isinstance(test.method_doc, str):
+            test.method_doc = test.method_doc.replace('"', "'")
         self.fields['results'].append(test)
         self.fields["testClass"].add(test.class_name)
         self.complete_output()
@@ -134,6 +136,8 @@ class TestResult(unittest.TestResult):
             test.class_name = res.group(2)
             test.method_name = res.group(1)
             test.method_doc = test.shortDescription()
+            if isinstance(test.method_doc, str):
+                test.method_doc = test.method_doc.replace('"', "'")
             self.fields['results'].append(test)
             self.fields["testClass"].add(test.class_name)
         else:


### PR DESCRIPTION
## 问题描述
当测试用例的description中存在双引号时，生成测试报告会出错
## 解决方法
生成`method_doc`时，替换掉双引号